### PR TITLE
T-104 add post-signup profile photo onboarding flow

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -5,13 +5,20 @@ import type { Session } from '@supabase/supabase-js';
 import LoginScreen from './src/screens/LoginScreen';
 import RegisterScreen from './src/screens/RegisterScreen';
 import HomeScreen from './src/screens/HomeScreen';
+import ProfilePhotoScreen from './src/screens/ProfilePhotoScreen';
 import { supabase, isSupabaseConfigured } from './src/lib/supabase';
 
 export type Screen = 'Login' | 'Register';
 
+type ProfileRecord = {
+  avatar_url: string | null;
+};
+
 export default function App() {
   const [session, setSession] = useState<Session | null>(null);
   const [authLoading, setAuthLoading] = useState(true);
+  const [profileLoading, setProfileLoading] = useState(false);
+  const [needsPhotoSetup, setNeedsPhotoSetup] = useState(false);
   const [screen, setScreen] = useState<Screen>('Login');
 
   useEffect(() => {
@@ -34,6 +41,36 @@ export default function App() {
     return () => subscription.unsubscribe();
   }, []);
 
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!session) {
+        setNeedsPhotoSetup(false);
+        setProfileLoading(false);
+        return;
+      }
+
+      setProfileLoading(true);
+      try {
+        const { data, error } = await supabase
+          .from('profiles')
+          .select('avatar_url')
+          .eq('id', session.user.id)
+          .maybeSingle<ProfileRecord>();
+
+        if (error) {
+          setNeedsPhotoSetup(true);
+          return;
+        }
+
+        setNeedsPhotoSetup(!data?.avatar_url);
+      } finally {
+        setProfileLoading(false);
+      }
+    };
+
+    void loadProfile();
+  }, [session]);
+
   if (!isSupabaseConfigured()) {
     return (
       <>
@@ -51,7 +88,7 @@ export default function App() {
     );
   }
 
-  if (authLoading) {
+  if (authLoading || profileLoading) {
     return (
       <View style={styles.loading}>
         <ActivityIndicator size="large" color="#4A90D9" />
@@ -63,7 +100,14 @@ export default function App() {
     return (
       <>
         <StatusBar style="dark" />
-        <HomeScreen />
+        {needsPhotoSetup ? (
+          <ProfilePhotoScreen
+            userId={session.user.id}
+            onComplete={() => setNeedsPhotoSetup(false)}
+          />
+        ) : (
+          <HomeScreen />
+        )}
       </>
     );
   }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "^2.1.2",
         "@supabase/supabase-js": "^2.49.1",
         "expo": "~54.0.33",
+        "expo-image-picker": "^55.0.18",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -60,6 +61,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1414,6 +1416,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3206,6 +3209,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3821,6 +3825,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4444,6 +4449,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -4504,6 +4510,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.18.tgz",
+      "integrity": "sha512-lGpPGRu+7mE8qN0ma2boRsCmfOGbdHZ2bXTpWVeWly0JCZdogGlTrYFnhTqgS8+lmiRb/UCOs7iTm2P5Rra6kw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -7535,6 +7562,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7553,6 +7581,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -7736,6 +7765,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8614,6 +8644,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8690,6 +8721,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,6 +13,7 @@
     "@react-native-async-storage/async-storage": "^2.1.2",
     "@supabase/supabase-js": "^2.49.1",
     "expo": "~54.0.33",
+    "expo-image-picker": "^55.0.18",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -20,7 +20,6 @@ export default function HomeScreen() {
   return (
     <View style={styles.root}>
       <Text style={styles.title}>{"You're signed in"}</Text>
-      <Text style={styles.subtitle}>Build your main app flow from here.</Text>
       {error ? <Text style={styles.error}>{error}</Text> : null}
       <TouchableOpacity
         style={[styles.btn, signingOut && styles.btnDisabled]}
@@ -47,11 +46,14 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 22, fontWeight: '700', color: '#111', marginBottom: 8 },
   subtitle: { fontSize: 15, color: '#666', textAlign: 'center', marginBottom: 28 },
-  error: { color: '#d32f2f', marginBottom: 16, textAlign: 'center' },
+  error: {
+    color: '#d32f2f',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
   btn: {
     backgroundColor: PRIMARY,
     paddingVertical: 14,
-    paddingHorizontal: 32,
     borderRadius: 10,
     minWidth: 160,
     alignItems: 'center',

--- a/mobile/src/screens/ProfilePhotoScreen.tsx
+++ b/mobile/src/screens/ProfilePhotoScreen.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  Image,
+  ScrollView,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import { supabase } from '../lib/supabase';
+
+type Props = {
+  userId: string;
+  onComplete: () => void;
+};
+
+const PRIMARY = '#4A90D9';
+const DEFAULT_AVATAR_URL =
+  'https://ui-avatars.com/api/?name=HabiMatch&background=E5EAF4&color=AEB7C5&size=256&rounded=true&bold=true';
+
+export default function ProfilePhotoScreen({ userId, onComplete }: Props) {
+  const [selectedAsset, setSelectedAsset] = useState<ImagePicker.ImagePickerAsset | null>(null);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const saveProfileAvatar = async (avatarUrl: string) => {
+    const { error: profileError } = await supabase.from('profiles').upsert(
+      {
+        id: userId,
+        avatar_url: avatarUrl,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+
+    if (profileError) {
+      throw profileError;
+    }
+  };
+
+  const handleChooseImage = async () => {
+    setError('');
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      setError('Allow photo access to choose a profile picture.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    });
+
+    if (!result.canceled) {
+      setSelectedAsset(result.assets[0] ?? null);
+    }
+  };
+
+  const handleSkip = async () => {
+    setError('');
+    setSaving(true);
+    try {
+      await saveProfileAvatar(DEFAULT_AVATAR_URL);
+      onComplete();
+    } catch {
+      setError('We could not save the default profile picture. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleContinue = async () => {
+    if (!selectedAsset?.uri) {
+      Alert.alert('Choose a photo', 'Select a profile picture or tap Skip for now.');
+      return;
+    }
+
+    setError('');
+    setSaving(true);
+
+    try {
+      const response = await fetch(selectedAsset.uri);
+      const imageBlob = await response.blob();
+      const fileExtension =
+        selectedAsset.fileName?.split('.').pop()?.toLowerCase()
+        ?? selectedAsset.mimeType?.split('/').pop()?.toLowerCase()
+        ?? 'jpg';
+      const contentType = selectedAsset.mimeType ?? imageBlob.type ?? 'image/jpeg';
+      const filePath = `${userId}/${Date.now()}.${fileExtension}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from('profile-photos')
+        .upload(filePath, imageBlob, {
+          contentType,
+          upsert: true,
+        });
+
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      const { data: publicUrlData } = supabase.storage
+        .from('profile-photos')
+        .getPublicUrl(filePath);
+
+      await saveProfileAvatar(publicUrlData.publicUrl);
+      onComplete();
+    } catch (uploadFailure) {
+      const detail =
+        uploadFailure instanceof Error ? uploadFailure.message : 'Unknown upload error.';
+      setError(`We could not upload your profile picture. ${detail}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View style={styles.root}>
+      <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+        <View style={styles.brand}>
+          <Text style={styles.logo}>HabiMatch</Text>
+          <Text style={styles.tagline}>Set up your first impression</Text>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Add a profile picture</Text>
+          <Text style={styles.cardSubtitle}>
+            Upload a photo now or skip for the moment and keep moving.
+          </Text>
+
+          <View style={styles.uploadFrame}>
+            <View style={styles.previewCircle}>
+              {selectedAsset?.uri ? (
+                <Image source={{ uri: selectedAsset.uri }} style={styles.previewImage} />
+              ) : (
+                <Ionicons name="cloud-upload-outline" size={42} color={PRIMARY} />
+              )}
+            </View>
+
+            <Text style={styles.uploadText}>
+              {selectedAsset?.uri ? 'Photo selected. You can continue or choose a different one.' : 'Choose an image to upload'}
+            </Text>
+
+            <TouchableOpacity style={styles.chooseBtn} onPress={handleChooseImage} disabled={saving}>
+              <Text style={styles.chooseBtnText}>
+                {selectedAsset?.uri ? 'Choose a different image' : 'Choose image'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <TouchableOpacity
+            style={[styles.primaryBtn, saving && styles.primaryBtnDisabled]}
+            onPress={handleContinue}
+            disabled={saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.primaryBtnText}>Continue</Text>
+            )}
+          </TouchableOpacity>
+
+          <TouchableOpacity style={styles.skipBtn} onPress={handleSkip} disabled={saving}>
+            <Text style={styles.skipBtnText}>Skip for now</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: PRIMARY },
+  scroll: { flexGrow: 1, justifyContent: 'center', padding: 24, backgroundColor: PRIMARY },
+  brand: { alignItems: 'center', marginBottom: 28 },
+  logo: { fontSize: 34, fontWeight: '700', color: '#fff', letterSpacing: 1 },
+  tagline: { fontSize: 14, color: 'rgba(255,255,255,0.85)', marginTop: 4 },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 20,
+    padding: 28,
+    shadowColor: '#000',
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
+  cardTitle: { fontSize: 22, fontWeight: '700', marginBottom: 4, color: '#111', textAlign: 'center' },
+  cardSubtitle: { fontSize: 14, color: '#666', marginBottom: 20, textAlign: 'center', lineHeight: 20 },
+  uploadFrame: {
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: '#E1E7F0',
+    borderRadius: 20,
+    paddingVertical: 30,
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    backgroundColor: '#FCFDFF',
+  },
+  previewCircle: {
+    width: 108,
+    height: 108,
+    borderRadius: 54,
+    borderWidth: 2,
+    borderColor: '#D9DEE8',
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    marginBottom: 18,
+  },
+  previewImage: { width: '100%', height: '100%' },
+  uploadText: { fontSize: 16, color: '#444', textAlign: 'center', marginBottom: 18, lineHeight: 22 },
+  chooseBtn: {
+    backgroundColor: PRIMARY,
+    borderRadius: 999,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+  },
+  chooseBtnText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+  error: {
+    color: '#d32f2f',
+    backgroundColor: '#fdecea',
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 16,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  primaryBtn: {
+    backgroundColor: PRIMARY,
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 20,
+  },
+  primaryBtnDisabled: { opacity: 0.7 },
+  primaryBtnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  skipBtn: { alignItems: 'center', marginTop: 16 },
+  skipBtnText: { color: PRIMARY, fontSize: 15, fontWeight: '700' },
+});


### PR DESCRIPTION
This PR adds a profile photo onboarding step after authentication in the mobile app.

Signed-in users are now checked for profiles.avatar_url before continuing into the app. If no avatar is present, they are shown a new profile photo screen where they can either upload an image or skip for now. Uploading stores the image in Supabase Storage and saves the returned public URL to the user’s profiles.avatar_url. Skipping saves a default avatar URL to the profile row so the onboarding step is completed either way.

The photo screen follows the existing HabiMatch login/register visual style so it fits the current UI without introducing a separate design system.

**What changed**

Added a post-auth gate based on whether profiles.avatar_url exists
Added a new profile photo upload/skip onboarding screen
Integrated Expo image picker for selecting a profile photo
Uploaded selected images to the profile-photos Supabase Storage bucket
Saved either the uploaded image URL or a default avatar URL to profiles.avatar_url
Kept the signed-in destination minimal with a basic sign-out view

**Files changed**

mobile/App.tsx
mobile/src/screens/ProfilePhotoScreen.tsx
mobile/src/screens/HomeScreen.tsx
mobile/package.json
mobile/package-lock.json

**Testing**

Completed manual testing for signup/sign-in flow
Verified skip path saves a default avatar URL
Verified upload path saves an uploaded image URL

**Notes**

During manual testing, email authentication/confirmation caused errors
To continue testing the profile photo flow, email verification was temporarily turned off
We will need to revisit and fix the email confirmation/auth redirect issue separately