### PR TITLE
Build roommate feed dashboard and discovery decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 # Expo
 mobile/.expo/
 mobile/dist/
+supabase/.temp/
 
 # Python
 __pycache__/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,3 +30,52 @@ def calculate_match_compatibility(
     _user: dict = Depends(require_auth),
 ):
     return calculate_compatibility(request.left, request.right)
+
+
+@app.get("/feed")
+def get_feed(user: dict = Depends(require_auth)):
+    # Mock profile suggestions for the mobile feed until this endpoint is backed by the profiles table.
+    return {
+        "suggestions": [
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "full_name": "Maya Chen",
+                "avatar_url": "https://example.com/maya.jpg",
+                "bio": "Clean, quiet, and looking for a respectful roommate.",
+                "age": 24,
+                "gender": "female",
+                "location": "Los Angeles, CA",
+                "questionnaire_complete": True,
+                "wake_time": "7:00 AM",
+                "sleep_time": "11:00 PM",
+                "cleanliness": "very_clean",
+                "noise_level": "quiet",
+                "wfh_frequency": "hybrid",
+                "social_level": "moderate",
+                "guest_frequency": "sometimes",
+                "smoking": "no",
+                "pets": "no",
+                "budget": "$1200-$1800",
+            },
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "full_name": "Jordan Lee",
+                "avatar_url": "https://example.com/jordan.jpg",
+                "bio": "Works hybrid, likes shared dinners, and keeps common spaces tidy.",
+                "age": 27,
+                "gender": "nonbinary",
+                "location": "Santa Monica, CA",
+                "questionnaire_complete": True,
+                "wake_time": "8:00 AM",
+                "sleep_time": "12:00 AM",
+                "cleanliness": "clean",
+                "noise_level": "moderate",
+                "wfh_frequency": "hybrid",
+                "social_level": "social",
+                "guest_frequency": "occasionally",
+                "smoking": "no",
+                "pets": "cat",
+                "budget": "$1500-$2200",
+            },
+        ]
+    }

--- a/backend/sql/allow_read_completed_profiles.sql
+++ b/backend/sql/allow_read_completed_profiles.sql
@@ -1,0 +1,11 @@
+drop policy if exists "Users can read own profile" on public.profiles;
+drop policy if exists "Authenticated users can read completed profiles" on public.profiles;
+
+create policy "Authenticated users can read completed profiles"
+on public.profiles
+for select
+to authenticated
+using (
+  questionnaire_complete = true
+  or id = auth.uid()
+);

--- a/backend/sql/tighten_profile_photo_storage_policies.sql
+++ b/backend/sql/tighten_profile_photo_storage_policies.sql
@@ -1,0 +1,3 @@
+drop policy if exists "Users can read profile photos" on storage.objects;
+drop policy if exists "Authenticated users can read profile photos" on storage.objects;
+drop policy if exists "Users can read own profile photos" on storage.objects;

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -27,3 +27,20 @@ def test_protected_invalid_signature(client, make_token):
 def test_protected_wrong_audience(client, make_token):
     response = client.get("/protected", headers={"Authorization": f"Bearer {make_token(aud='wrong')}"})
     assert response.status_code == 401
+
+
+def test_feed_no_token(client):
+    # The feed is user-specific, so it should reject requests without an auth token.
+    assert client.get("/feed").status_code == 403
+
+
+def test_feed_valid_token(client, make_token):
+    # Verifies the temporary mock feed response shape the mobile feed can render against.
+    response = client.get("/feed", headers={"Authorization": f"Bearer {make_token()}"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "suggestions" in data
+    assert len(data["suggestions"]) > 0
+    assert data["suggestions"][0]["id"]
+    assert data["suggestions"][0]["full_name"]

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -15,6 +15,8 @@ export type Screen = 'Login' | 'Register';
 type ProfileRecord = {
   avatar_url: string | null;
   birthdate: string | null;
+  full_name: string | null;
+  location: string | null;
   questionnaire_complete: boolean | null;
 };
 
@@ -165,7 +167,7 @@ export default function App() {
     try {
       const { data, error } = await supabase
         .from('profiles')
-        .select('avatar_url, birthdate, questionnaire_complete')
+        .select('avatar_url, birthdate, full_name, location, questionnaire_complete')
         .eq('id', activeSession.user.id)
         .maybeSingle<ProfileRecord>();
 
@@ -184,7 +186,7 @@ export default function App() {
       }
 
       setOnboardingState({
-        needsBasicInfo: !data?.birthdate,
+        needsBasicInfo: !data?.birthdate || !data?.full_name?.trim() || !data?.location?.trim(),
         needsPhotoSetup: !data?.avatar_url,
         needsQuestionnaire: !data?.questionnaire_complete,
       });

--- a/mobile/src/lib/matching.ts
+++ b/mobile/src/lib/matching.ts
@@ -9,13 +9,9 @@ export type MatchPreferences = {
   okWithAlcohol: boolean;
   hasPets: boolean;
   okWithPets: boolean;
-  partnerStaysOver: boolean;
-  okWithPartnersStaying: boolean;
-  sharesFood: boolean;
-  okWithCoed: boolean;
+  partnerStaysOver: number;
+  okWithPartnersStaying: number;
   studyOrWfh: boolean;
-  preferredAgeMin: number;
-  preferredAgeMax: number;
   budgetMin: number;
   budgetMax: number;
   moveInDate: string;
@@ -31,7 +27,6 @@ export type MatchPreferences = {
   guestToleranceScore: number;
   conflictBehaviorScore: number;
   conflictToleranceScore: number;
-  cohabitationBehaviorScore: number;
   cohabitationToleranceScore: number;
 };
 
@@ -160,9 +155,14 @@ function booleanPairCompatible(
 
 function normalizedWeights(left: MatchParticipant, right: MatchParticipant): Record<DomainKey, number> {
   const weights = { ...BASE_DOMAIN_WEIGHTS };
-  if (left.preferences.studyOrWfh || right.preferences.studyOrWfh) {
-    weights.noise *= NOISE_WFH_MULTIPLIER;
-  }
+  const leftSensitivity = left.preferences.studyOrWfh
+    ? (SCORE_MAX - left.preferences.noiseToleranceScore) / SCORE_MAX
+    : 0;
+  const rightSensitivity = right.preferences.studyOrWfh
+    ? (SCORE_MAX - right.preferences.noiseToleranceScore) / SCORE_MAX
+    : 0;
+  const wfhSensitivity = Math.max(leftSensitivity, rightSensitivity);
+  weights.noise *= 1 + (NOISE_WFH_MULTIPLIER - 1) * wfhSensitivity;
 
   const total = DOMAIN_KEYS.reduce((sum, key) => sum + weights[key], 0);
   return DOMAIN_KEYS.reduce(
@@ -182,23 +182,10 @@ export function calculateCompatibility(
   const budgetOverlapRatio = overlapRatio(leftP.budgetMin, leftP.budgetMax, rightP.budgetMin, rightP.budgetMax);
   const gapDays = moveInGapDays(leftP.moveInDate, rightP.moveInDate);
   const moveInCompatible = gapDays <= MOVE_IN_MAX_GAP_DAYS;
-  const ageCompatible = (
-    rightP.preferredAgeMin <= left.age
-    && left.age <= rightP.preferredAgeMax
-    && leftP.preferredAgeMin <= right.age
-    && right.age <= leftP.preferredAgeMax
-  );
-
-  let coedCompatible = true;
-  if (left.gender && right.gender && left.gender !== right.gender) {
-    coedCompatible = leftP.okWithCoed && rightP.okWithCoed;
-  }
 
   const failures: string[] = [];
   if (!budgetOverlap) failures.push('Budget ranges do not overlap.');
   if (!moveInCompatible) failures.push('Move-in timelines are too far apart.');
-  if (!ageCompatible) failures.push('Age preferences are not mutually compatible.');
-  if (!coedCompatible) failures.push('Coed living preference is not mutually compatible.');
   if (!booleanPairCompatible(leftP.smokes, leftP.okWithSmoking, rightP.smokes, rightP.okWithSmoking)) {
     failures.push('Smoking preference is not mutually compatible.');
   }
@@ -211,9 +198,6 @@ export function calculateCompatibility(
   if (!booleanPairCompatible(leftP.hasPets, leftP.okWithPets, rightP.hasPets, rightP.okWithPets)) {
     failures.push('Pet preference is not mutually compatible.');
   }
-  if (!booleanPairCompatible(leftP.partnerStaysOver, leftP.okWithPartnersStaying, rightP.partnerStaysOver, rightP.okWithPartnersStaying)) {
-    failures.push('Overnight guest preference is not mutually compatible.');
-  }
 
   if (failures.length > 0) {
     return {
@@ -225,9 +209,8 @@ export function calculateCompatibility(
   }
 
   const logisticsScore = (
-    budgetOverlapRatio * 0.45
-    + moveInScore(gapDays) * 0.45
-    + (leftP.sharesFood === rightP.sharesFood ? 1 : 0.5) * 0.10
+    budgetOverlapRatio * 0.50
+    + moveInScore(gapDays) * 0.50
   );
   const sleepScore = thresholdScore(
     leftP.sleepBehaviorScore,
@@ -253,24 +236,26 @@ export function calculateCompatibility(
     rightP.noiseBehaviorScore,
     rightP.noiseToleranceScore,
   );
-  const guestsScore = thresholdScore(
+  const generalGuestsScore = thresholdScore(
     leftP.guestBehaviorScore,
     leftP.guestToleranceScore,
     rightP.guestBehaviorScore,
     rightP.guestToleranceScore,
   );
+  const overnightScore = thresholdScore(
+    leftP.partnerStaysOver,
+    leftP.okWithPartnersStaying,
+    rightP.partnerStaysOver,
+    rightP.okWithPartnersStaying,
+  );
+  const guestsScore = (generalGuestsScore + overnightScore) / 2;
   const conflictScore = pairedSimilarityScore(
     leftP.conflictBehaviorScore,
     leftP.conflictToleranceScore,
     rightP.conflictBehaviorScore,
     rightP.conflictToleranceScore,
   );
-  const cohabitationScore = pairedSimilarityScore(
-    leftP.cohabitationBehaviorScore,
-    leftP.cohabitationToleranceScore,
-    rightP.cohabitationBehaviorScore,
-    rightP.cohabitationToleranceScore,
-  );
+  const cohabitationScore = similarityScore(leftP.cohabitationToleranceScore, rightP.cohabitationToleranceScore);
 
   const domains: Record<DomainKey, number> = {
     logistics: round4(logisticsScore),

--- a/mobile/src/lib/profilePhotos.ts
+++ b/mobile/src/lib/profilePhotos.ts
@@ -1,0 +1,86 @@
+import { supabase } from './supabase';
+
+type ImageAsset = {
+  uri: string;
+  base64?: string | null;
+  fileName?: string | null;
+  mimeType?: string | null;
+};
+
+function blobFromUri(uri: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.onload = () => {
+      resolve(request.response as Blob);
+    };
+    request.onerror = () => {
+      reject(new Error('Could not read the selected image.'));
+    };
+    request.responseType = 'blob';
+    request.open('GET', uri, true);
+    request.send(null);
+  });
+}
+
+function bytesFromBase64(base64: string): Uint8Array {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  const clean = base64.replace(/[^A-Za-z0-9+/=]/g, '');
+  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0;
+  const outputLength = Math.floor((clean.length * 3) / 4) - padding;
+  const bytes = new Uint8Array(outputLength);
+
+  let buffer = 0;
+  let bits = 0;
+  let index = 0;
+
+  for (const char of clean) {
+    if (char === '=') break;
+    const value = chars.indexOf(char);
+    if (value < 0) continue;
+
+    buffer = (buffer << 6) | value;
+    bits += 6;
+
+    if (bits >= 8) {
+      bits -= 8;
+      bytes[index] = (buffer >> bits) & 0xff;
+      index += 1;
+    }
+  }
+
+  return bytes;
+}
+
+export async function uploadProfilePhoto(userId: string, asset: ImageAsset): Promise<string> {
+  const fileExtension =
+    asset.fileName?.split('.').pop()?.toLowerCase()
+    ?? asset.mimeType?.split('/').pop()?.toLowerCase()
+    ?? 'jpg';
+  const contentType = asset.mimeType ?? 'image/jpeg';
+  const filePath = `${userId}/${Date.now()}.${fileExtension}`;
+  const fileBody = asset.base64
+    ? bytesFromBase64(asset.base64)
+    : await blobFromUri(asset.uri);
+  const fileSize = 'size' in fileBody ? fileBody.size : fileBody.byteLength;
+
+  if (!fileSize) {
+    throw new Error('Selected image was empty. Choose a different photo and try again.');
+  }
+
+  const { error: uploadError } = await supabase.storage
+    .from('profile-photos')
+    .upload(filePath, fileBody, {
+      contentType,
+      upsert: true,
+    });
+
+  if (uploadError) {
+    throw uploadError;
+  }
+
+  const { data: publicUrlData } = supabase.storage
+    .from('profile-photos')
+    .getPublicUrl(filePath);
+
+  return publicUrlData.publicUrl;
+}

--- a/mobile/src/screens/BasicInfoScreen.tsx
+++ b/mobile/src/screens/BasicInfoScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   ScrollView,
@@ -16,6 +17,7 @@ type Props = {
 };
 
 const PRIMARY = '#4A90D9';
+type BasicInfoStep = 'profile' | 'details';
 
 const GENDER_OPTIONS = [
   { label: 'Man', value: 'man' },
@@ -35,13 +37,18 @@ const defaultBirthdate = (() => {
 })();
 
 export default function BasicInfoScreen({ userId, onComplete }: Props) {
+  const [step, setStep] = useState<BasicInfoStep>('profile');
+  const [fullName, setFullName] = useState('');
+  const [location, setLocation] = useState('');
   const [birthdate, setBirthdate] = useState(defaultBirthdate);
   const [gender, setGender] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
   const ageError = !isAtLeast18(birthdate);
-  const isComplete = !ageError && gender !== '';
+  const profileComplete = fullName.trim() !== '' && location.trim() !== '';
+  const detailsComplete = !ageError && gender !== '';
+  const isComplete = profileComplete && detailsComplete;
 
   const handleDateChange = (_: DateTimePickerEvent, date?: Date) => {
     if (date) setBirthdate(date);
@@ -56,6 +63,8 @@ export default function BasicInfoScreen({ userId, onComplete }: Props) {
         .from('profiles')
         .upsert({
           id: userId,
+          full_name: fullName.trim(),
+          location: location.trim(),
           birthdate: birthdate.toISOString().split('T')[0],
           gender,
           updated_at: new Date().toISOString(),
@@ -79,59 +88,107 @@ export default function BasicInfoScreen({ userId, onComplete }: Props) {
         </View>
 
         <View style={styles.card}>
-          <Text style={styles.sectionLabel}>Date of Birth</Text>
-          <Text style={styles.question}>When were you born?</Text>
+          {step === 'profile' ? (
+            <>
+              <Text style={styles.sectionLabel}>Profile</Text>
+              <Text style={styles.question}>What should roommates call you?</Text>
 
-          <View style={styles.datePickerWrap}>
-            <DateTimePicker
-              value={birthdate}
-              mode="date"
-              display="spinner"
-              onChange={handleDateChange}
-              maximumDate={new Date()}
-              style={styles.datePicker}
-            />
-          </View>
+              <TextInput
+                style={styles.input}
+                value={fullName}
+                onChangeText={setFullName}
+                editable={!saving}
+                placeholder="Full name"
+                placeholderTextColor="#aaa"
+                autoCapitalize="words"
+                autoCorrect={false}
+              />
 
-          {ageError && (
-            <Text style={styles.ageError}>
-              You must be at least 18 years old to use HabiMatch.
-            </Text>
-          )}
+              <Text style={styles.question}>Where are you looking?</Text>
 
-          <View style={styles.divider} />
+              <TextInput
+                style={styles.input}
+                value={location}
+                onChangeText={setLocation}
+                editable={!saving}
+                placeholder="City, state"
+                placeholderTextColor="#aaa"
+                autoCapitalize="words"
+              />
 
-          <Text style={styles.sectionLabel}>Gender</Text>
-          <Text style={styles.question}>How do you identify?</Text>
-
-          <View style={styles.genderGrid}>
-            {GENDER_OPTIONS.map(g => (
               <TouchableOpacity
-                key={g.value}
-                style={[styles.genderOption, gender === g.value && styles.genderOptionSelected]}
-                onPress={() => setGender(g.value)}
+                style={[styles.continueBtn, (!profileComplete || saving) && styles.continueBtnDisabled]}
+                onPress={() => setStep('details')}
+                disabled={!profileComplete || saving}
+              >
+                <Text style={styles.continueBtnText}>Next</Text>
+              </TouchableOpacity>
+            </>
+          ) : (
+            <>
+              <Text style={styles.sectionLabel}>Date of Birth</Text>
+              <Text style={styles.question}>When were you born?</Text>
+
+              <View style={styles.datePickerWrap}>
+                <DateTimePicker
+                  value={birthdate}
+                  mode="date"
+                  display="spinner"
+                  onChange={handleDateChange}
+                  maximumDate={new Date()}
+                  style={styles.datePicker}
+                />
+              </View>
+
+              {ageError && (
+                <Text style={styles.ageError}>
+                  You must be at least 18 years old to use HabiMatch.
+                </Text>
+              )}
+
+              <View style={styles.divider} />
+
+              <Text style={styles.sectionLabel}>Gender</Text>
+              <Text style={styles.question}>How do you identify?</Text>
+
+              <View style={styles.genderGrid}>
+                {GENDER_OPTIONS.map(g => (
+                  <TouchableOpacity
+                    key={g.value}
+                    style={[styles.genderOption, gender === g.value && styles.genderOptionSelected]}
+                    onPress={() => setGender(g.value)}
+                    disabled={saving}
+                  >
+                    <Text style={[styles.genderText, gender === g.value && styles.genderTextSelected]}>
+                      {g.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+
+              {error ? <Text style={styles.errorBanner}>{error}</Text> : null}
+
+              <TouchableOpacity
+                style={[styles.continueBtn, (!detailsComplete || saving) && styles.continueBtnDisabled]}
+                onPress={handleSave}
+                disabled={!detailsComplete || saving}
+              >
+                {saving ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={styles.continueBtnText}>Continue</Text>
+                )}
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.backBtn}
+                onPress={() => setStep('profile')}
                 disabled={saving}
               >
-                <Text style={[styles.genderText, gender === g.value && styles.genderTextSelected]}>
-                  {g.label}
-                </Text>
+                <Text style={styles.backBtnText}>Back</Text>
               </TouchableOpacity>
-            ))}
-          </View>
-
-          {error ? <Text style={styles.errorBanner}>{error}</Text> : null}
-
-          <TouchableOpacity
-            style={[styles.continueBtn, (!isComplete || saving) && styles.continueBtnDisabled]}
-            onPress={handleSave}
-            disabled={!isComplete || saving}
-          >
-            {saving ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <Text style={styles.continueBtnText}>Continue</Text>
-            )}
-          </TouchableOpacity>
+            </>
+          )}
         </View>
       </ScrollView>
     </View>
@@ -163,6 +220,17 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   question: { fontSize: 20, fontWeight: '700', color: '#111', lineHeight: 28, marginBottom: 12 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '#111',
+    marginBottom: 16,
+    backgroundColor: '#fafafa',
+  },
   datePickerWrap: { alignItems: 'center' },
   datePicker: { width: '100%' },
   ageError: { color: '#d32f2f', fontSize: 14, textAlign: 'center', marginTop: 4 },
@@ -197,4 +265,6 @@ const styles = StyleSheet.create({
   },
   continueBtnDisabled: { opacity: 0.4 },
   continueBtnText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+  backBtn: { alignItems: 'center', marginTop: 16 },
+  backBtnText: { color: PRIMARY, fontSize: 15, fontWeight: '700' },
 });

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -80,6 +80,8 @@ type RankedMatch = {
   domains: Record<DomainKey, number>;
 };
 
+type DiscoveryDecision = 'like' | 'dislike';
+
 const PRIMARY = '#4A90D9';
 const TEXT = '#111827';
 const MUTED = '#6B7280';
@@ -147,6 +149,8 @@ export default function HomeScreen() {
   const [profileSaveError, setProfileSaveError] = useState('');
   const [profileSaveMessage, setProfileSaveMessage] = useState('');
   const [failedImageUrls, setFailedImageUrls] = useState<Set<string>>(new Set());
+  const [savingDecision, setSavingDecision] = useState<DiscoveryDecision | null>(null);
+  const [decisionError, setDecisionError] = useState('');
 
   const markImageFailed = (url: string) => {
     setFailedImageUrls(current => new Set(current).add(url));
@@ -155,6 +159,7 @@ export default function HomeScreen() {
   const loadRankings = async () => {
     setLoadingMatches(true);
     setRankingError('');
+    setDecisionError('');
 
     try {
       const { data: authData, error: userError } = await supabase.auth.getUser();
@@ -181,8 +186,19 @@ export default function HomeScreen() {
         .select(PREFERENCE_COLUMNS);
       if (preferenceError) throw preferenceError;
 
+      const { data: decisionData, error: discoveryError } = await supabase
+        .from('discovery_decisions')
+        .select('target_user_id')
+        .eq('user_id', userId);
+      if (discoveryError) throw discoveryError;
+
       const profiles = (profileData ?? []) as ProfileRecord[];
       const preferences = (preferenceData ?? []) as unknown as PreferenceRecord[];
+      const decidedUserIds = new Set(
+        ((decisionData ?? []) as { target_user_id: string | null }[])
+          .map(row => row.target_user_id)
+          .filter((id): id is string => Boolean(id)),
+      );
       const preferencesByUser = new Map(preferences.map(row => [row.user_id, row]));
       const currentProfile = profiles.find(profile => profile.id === userId) ?? null;
       const currentPreferences = preferencesByUser.get(userId) ?? null;
@@ -213,7 +229,7 @@ export default function HomeScreen() {
 
       let skipped = 0;
       const ranked = profiles
-        .filter(profile => profile.id !== userId)
+        .filter(profile => profile.id !== userId && !decidedUserIds.has(profile.id))
         .map(profile => {
           const candidatePreferences = preferencesByUser.get(profile.id) ?? null;
           const candidate = toParticipant(profile, candidatePreferences);
@@ -371,6 +387,38 @@ export default function HomeScreen() {
     }
   };
 
+  const handleDiscoveryDecision = async (decision: DiscoveryDecision) => {
+    if (!topMatch || savingDecision) return;
+
+    setSavingDecision(decision);
+    setDecisionError('');
+
+    try {
+      const { data: authData, error: userError } = await supabase.auth.getUser();
+      if (userError) throw userError;
+      const userId = authData.user?.id;
+      if (!userId) throw new Error('No signed-in user found.');
+
+      const { error } = await supabase
+        .from('discovery_decisions')
+        .upsert({
+          user_id: userId,
+          target_user_id: topMatch.userId,
+          decision,
+        }, {
+          onConflict: 'user_id,target_user_id',
+        });
+      if (error) throw error;
+
+      setMatches(current => current.filter(match => match.userId !== topMatch.userId));
+    } catch (error) {
+      console.error('Could not save discovery decision', error);
+      setDecisionError('Could not save your choice. Please try again.');
+    } finally {
+      setSavingDecision(null);
+    }
+  };
+
   const topMatch = matches[0] ?? null;
 
   return (
@@ -435,11 +483,35 @@ export default function HomeScreen() {
                 </View>
 
                 <View style={styles.actionRow}>
-                  <TouchableOpacity style={[styles.roundAction, styles.rejectAction]} disabled>
-                    <Ionicons name="close" size={24} color="#B42318" />
+                  <TouchableOpacity
+                    style={[
+                      styles.roundAction,
+                      styles.rejectAction,
+                      savingDecision && styles.actionDisabled,
+                    ]}
+                    onPress={() => void handleDiscoveryDecision('dislike')}
+                    disabled={Boolean(savingDecision)}
+                  >
+                    {savingDecision === 'dislike' ? (
+                      <ActivityIndicator color="#B42318" />
+                    ) : (
+                      <Ionicons name="close" size={24} color="#B42318" />
+                    )}
                   </TouchableOpacity>
-                  <TouchableOpacity style={[styles.roundAction, styles.acceptAction]} disabled>
-                    <Ionicons name="checkmark" size={24} color="#067647" />
+                  <TouchableOpacity
+                    style={[
+                      styles.roundAction,
+                      styles.acceptAction,
+                      savingDecision && styles.actionDisabled,
+                    ]}
+                    onPress={() => void handleDiscoveryDecision('like')}
+                    disabled={Boolean(savingDecision)}
+                  >
+                    {savingDecision === 'like' ? (
+                      <ActivityIndicator color="#067647" />
+                    ) : (
+                      <Ionicons name="checkmark" size={24} color="#067647" />
+                    )}
                   </TouchableOpacity>
                 </View>
               </View>
@@ -451,6 +523,8 @@ export default function HomeScreen() {
                 </Text>
               </View>
             )}
+
+            {decisionError ? <Text style={styles.authError}>{decisionError}</Text> : null}
 
             <View style={styles.feedMetaRow}>
               <Text style={styles.feedMetaText}>
@@ -966,6 +1040,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 1,
+  },
+  actionDisabled: {
+    opacity: 0.55,
   },
   rejectAction: {
     backgroundColor: '#FEEDEB',

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  Image,
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 import { supabase } from '../lib/supabase';
+import { uploadProfilePhoto } from '../lib/profilePhotos';
 import {
   calculateCompatibility,
   type DomainKey,
@@ -18,8 +23,12 @@ import {
 
 type ProfileRecord = {
   id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
   birthdate: string | null;
   gender: string | null;
+  location: string | null;
   questionnaire_complete: boolean | null;
 };
 
@@ -33,13 +42,9 @@ type PreferenceRecord = {
   ok_with_alcohol: boolean | null;
   has_pets: boolean | null;
   ok_with_pets: boolean | null;
-  partner_stays_over: boolean | null;
-  ok_with_partners_staying: boolean | null;
-  shares_food: boolean | null;
-  ok_with_coed: boolean | null;
+  partner_stays_over: number | null;
+  ok_with_partners_staying: number | null;
   study_or_wfh: boolean | null;
-  preferred_age_min: number | null;
-  preferred_age_max: number | null;
   budget_min: number | null;
   budget_max: number | null;
   move_in_date: string | null;
@@ -60,8 +65,15 @@ type PreferenceRecord = {
 
 type RankedMatch = {
   userId: string;
+  fullName: string | null;
+  avatarUrl: string | null;
+  bio: string | null;
+  location: string | null;
   age: number;
   gender: Gender;
+  budgetMin: number;
+  budgetMax: number;
+  moveInDate: string;
   score: number;
   passedFilters: boolean;
   failures: string[];
@@ -69,6 +81,11 @@ type RankedMatch = {
 };
 
 const PRIMARY = '#4A90D9';
+const TEXT = '#111827';
+const MUTED = '#6B7280';
+const CARD = '#FFFFFF';
+
+type DashboardTab = 'feed' | 'profile';
 const DOMAIN_LABELS: Record<DomainKey, string> = {
   logistics: 'Logistics',
   sleep: 'Sleep',
@@ -91,11 +108,7 @@ const PREFERENCE_COLUMNS = [
   'ok_with_pets',
   'partner_stays_over',
   'ok_with_partners_staying',
-  'shares_food',
-  'ok_with_coed',
   'study_or_wfh',
-  'preferred_age_min',
-  'preferred_age_max',
   'budget_min',
   'budget_max',
   'move_in_date',
@@ -122,7 +135,22 @@ export default function HomeScreen() {
   const [authError, setAuthError] = useState('');
   const [rankingError, setRankingError] = useState('');
   const [matches, setMatches] = useState<RankedMatch[]>([]);
+  const [currentUser, setCurrentUser] = useState<RankedMatch | null>(null);
+  const [selfProfile, setSelfProfile] = useState<ProfileRecord | null>(null);
   const [skippedCount, setSkippedCount] = useState(0);
+  const [activeTab, setActiveTab] = useState<DashboardTab>('feed');
+  const [profileName, setProfileName] = useState('');
+  const [profileBio, setProfileBio] = useState('');
+  const [profileLocation, setProfileLocation] = useState('');
+  const [updatingPhoto, setUpdatingPhoto] = useState(false);
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [profileSaveError, setProfileSaveError] = useState('');
+  const [profileSaveMessage, setProfileSaveMessage] = useState('');
+  const [failedImageUrls, setFailedImageUrls] = useState<Set<string>>(new Set());
+
+  const markImageFailed = (url: string) => {
+    setFailedImageUrls(current => new Set(current).add(url));
+  };
 
   const loadRankings = async () => {
     setLoadingMatches(true);
@@ -136,9 +164,17 @@ export default function HomeScreen() {
 
       const { data: profileData, error: profileError } = await supabase
         .from('profiles')
-        .select('id,birthdate,gender,questionnaire_complete')
+        .select('id,full_name,avatar_url,bio,birthdate,gender,location,questionnaire_complete')
         .eq('questionnaire_complete', true);
       if (profileError) throw profileError;
+
+      const { data: selfData, error: selfError } = await supabase
+        .from('profiles')
+        .select('id,full_name,avatar_url,bio,birthdate,gender,location,questionnaire_complete')
+        .eq('id', userId)
+        .maybeSingle<ProfileRecord>();
+      if (selfError) throw selfError;
+      setSelfProfile(selfData ?? null);
 
       const { data: preferenceData, error: preferenceError } = await supabase
         .from('lifestyle_preferences')
@@ -152,33 +188,47 @@ export default function HomeScreen() {
       const currentPreferences = preferencesByUser.get(userId) ?? null;
       const currentParticipant = toParticipant(currentProfile, currentPreferences);
 
-      if (!currentParticipant) {
+      if (!currentProfile || !currentPreferences || !currentParticipant) {
         setMatches([]);
+        setCurrentUser(null);
         setSkippedCount(0);
         setRankingError('Complete your profile and questionnaire before matching.');
         return;
       }
 
+      setCurrentUser(toRankedProfile(currentParticipant, currentProfile, currentPreferences, {
+        score: 1,
+        passedFilters: true,
+        failures: [],
+        domains: {
+          logistics: 1,
+          sleep: 1,
+          cleanliness: 1,
+          noise: 1,
+          guests: 1,
+          cohabitation: 1,
+          conflict: 1,
+        },
+      }));
+
       let skipped = 0;
       const ranked = profiles
         .filter(profile => profile.id !== userId)
         .map(profile => {
-          const candidate = toParticipant(profile, preferencesByUser.get(profile.id) ?? null);
-          if (!candidate) {
+          const candidatePreferences = preferencesByUser.get(profile.id) ?? null;
+          const candidate = toParticipant(profile, candidatePreferences);
+          if (!candidate || !candidatePreferences) {
             skipped += 1;
             return null;
           }
 
           const result = calculateCompatibility(currentParticipant, candidate);
-          return {
-            userId: candidate.userId,
-            age: candidate.age,
-            gender: candidate.gender,
+          return toRankedProfile(candidate, profile, candidatePreferences, {
             score: result.overallScore,
             passedFilters: result.passedFilters,
             failures: result.failures,
             domains: result.domains,
-          };
+          });
         })
         .filter((match): match is RankedMatch => match !== null)
         .sort((left, right) => {
@@ -193,6 +243,8 @@ export default function HomeScreen() {
       setSkippedCount(skipped);
     } catch (error) {
       setMatches([]);
+      setCurrentUser(null);
+      setSelfProfile(null);
       setSkippedCount(0);
       setRankingError(error instanceof Error ? error.message : 'Could not load compatibility rankings.');
     } finally {
@@ -203,6 +255,15 @@ export default function HomeScreen() {
   useEffect(() => {
     void loadRankings();
   }, []);
+
+  useEffect(() => {
+    if (!selfProfile) return;
+    setProfileName(selfProfile.full_name ?? '');
+    setProfileBio(selfProfile.bio ?? '');
+    setProfileLocation(selfProfile.location ?? '');
+    setProfileSaveError('');
+    setProfileSaveMessage('');
+  }, [selfProfile?.id]);
 
   const handleSignOut = async () => {
     setAuthError('');
@@ -215,84 +276,335 @@ export default function HomeScreen() {
     }
   };
 
+  const handleSaveProfile = async () => {
+    if (!selfProfile) return;
+
+    setSavingProfile(true);
+    setProfileSaveError('');
+    setProfileSaveMessage('');
+
+    try {
+      const nextName = profileName.trim();
+      const nextBio = profileBio.trim();
+      const nextLocation = profileLocation.trim();
+      if (!nextName) {
+        setProfileSaveError('Display name is required.');
+        return;
+      }
+      if (!nextLocation) {
+        setProfileSaveError('Location is required.');
+        return;
+      }
+
+      const { error } = await supabase
+        .from('profiles')
+        .update({
+          full_name: nextName,
+          bio: nextBio || null,
+          location: nextLocation,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', selfProfile.id);
+
+      if (error) throw error;
+
+      setSelfProfile(current => current
+        ? { ...current, full_name: nextName, bio: nextBio || null, location: nextLocation }
+        : current);
+      setCurrentUser(current => current
+        ? { ...current, fullName: nextName, bio: nextBio || null, location: nextLocation }
+        : current);
+      setProfileSaveMessage('Profile updated.');
+    } catch {
+      setProfileSaveError('Could not save your profile. Please try again.');
+    } finally {
+      setSavingProfile(false);
+    }
+  };
+
+  const handleChooseProfilePhoto = async () => {
+    if (!selfProfile) return;
+
+    setProfileSaveError('');
+    setProfileSaveMessage('');
+
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      setProfileSaveError('Allow photo access to choose a profile picture.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+      base64: true,
+    });
+
+    if (result.canceled) return;
+
+    const selectedAsset = result.assets[0];
+    if (!selectedAsset?.uri) return;
+
+    setUpdatingPhoto(true);
+
+    try {
+      const avatarUrl = await uploadProfilePhoto(selfProfile.id, selectedAsset);
+
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .update({
+          avatar_url: avatarUrl,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', selfProfile.id);
+      if (profileError) throw profileError;
+
+      setSelfProfile(current => current ? { ...current, avatar_url: avatarUrl } : current);
+      setCurrentUser(current => current ? { ...current, avatarUrl } : current);
+      setProfileSaveMessage('Profile picture updated.');
+    } catch {
+      setProfileSaveError('Could not update your profile picture. Please try again.');
+    } finally {
+      setUpdatingPhoto(false);
+    }
+  };
+
+  const topMatch = matches[0] ?? null;
+
   return (
-    <ScrollView contentContainerStyle={styles.root}>
-      <View style={styles.header}>
-        <Text style={styles.title}>{"You're signed in"}</Text>
-        <Text style={styles.subtitle}>Compatibility ranking for the current questionnaire.</Text>
-      </View>
+    <View style={styles.shell}>
+      <ScrollView contentContainerStyle={styles.root} showsVerticalScrollIndicator={false}>
+        {activeTab === 'feed' ? (
+          <>
+            <View style={styles.topBar}>
+              <View>
+                <Text style={styles.logo}>HM</Text>
+                <Text style={styles.screenTitle}>Roommate Feed</Text>
+              </View>
+              <TouchableOpacity style={styles.iconTextBtn} disabled>
+                <Ionicons name="swap-vertical-outline" size={17} color={PRIMARY} />
+                <Text style={styles.iconText}>Sort</Text>
+              </TouchableOpacity>
+            </View>
 
-      <View style={styles.panel}>
-        <View style={styles.panelHeader}>
-          <View>
-            <Text style={styles.sectionLabel}>Roommate matches</Text>
-            <Text style={styles.panelSubtitle}>
-              {matches.length > 0
-                ? `${matches.length} ranked ${skippedCount > 0 ? `(${skippedCount} incomplete skipped)` : ''}`
-                : 'No ranked matches yet'}
-            </Text>
-          </View>
-          <TouchableOpacity style={styles.refreshBtn} onPress={loadRankings} disabled={loadingMatches}>
-            <Text style={styles.refreshText}>Refresh</Text>
-          </TouchableOpacity>
-        </View>
+            {rankingError ? <Text style={styles.errorBanner}>{rankingError}</Text> : null}
 
-        {rankingError ? <Text style={styles.errorBanner}>{rankingError}</Text> : null}
-
-        {loadingMatches ? (
-          <View style={styles.loadingWrap}>
-            <ActivityIndicator color={PRIMARY} />
-            <Text style={styles.loadingText}>Scoring matches...</Text>
-          </View>
-        ) : (
-          <View style={styles.matchList}>
-            {matches.length === 0 && !rankingError ? (
-              <Text style={styles.emptyText}>
-                No completed roommate profiles are visible yet.
-              </Text>
-            ) : null}
-
-            {matches.map((match, index) => (
-              <View key={match.userId} style={styles.matchCard}>
-                <View style={styles.matchTopRow}>
+            {loadingMatches ? (
+              <View style={styles.stateCard}>
+                <ActivityIndicator color={PRIMARY} />
+                <Text style={styles.loadingText}>Scoring matches...</Text>
+              </View>
+            ) : topMatch ? (
+              <View style={styles.heroCard}>
+                <View style={styles.matchHeader}>
                   <View>
-                    <Text style={styles.matchName}>
-                      #{index + 1} User {shortUserId(match.userId)}
-                    </Text>
-                    <Text style={styles.matchMeta}>
-                      {formatGender(match.gender)} - {match.age} years old
-                    </Text>
+                    <Text style={styles.matchName}>{displayName(topMatch)}</Text>
+                    <Text style={styles.matchMeta}>{formatProfileMeta(topMatch)}</Text>
                   </View>
-                  <View style={[styles.scorePill, !match.passedFilters && styles.filteredPill]}>
-                    <Text style={[styles.scoreText, !match.passedFilters && styles.filteredText]}>
-                      {match.passedFilters ? `${formatPercent(match.score)}%` : 'Filtered'}
+                  <View style={[styles.scorePill, !topMatch.passedFilters && styles.filteredPill]}>
+                    <Text style={[styles.scoreText, !topMatch.passedFilters && styles.filteredText]}>
+                      {topMatch.passedFilters ? `${formatPercent(topMatch.score)}%` : 'Filtered'}
                     </Text>
                   </View>
                 </View>
 
-                <Text style={styles.matchDetail}>
-                  {match.passedFilters
-                    ? topDomainSummary(match.domains)
-                    : match.failures[0] ?? 'Failed a dealbreaker filter.'}
+                <View style={styles.photoFrame}>
+                  {topMatch.avatarUrl && !failedImageUrls.has(topMatch.avatarUrl) ? (
+                    <Image
+                      source={{ uri: topMatch.avatarUrl }}
+                      style={styles.profileImage}
+                      onError={() => markImageFailed(topMatch.avatarUrl as string)}
+                    />
+                  ) : (
+                    <View style={styles.photoFallback}>
+                      <Text style={styles.photoInitial}>{displayInitial(topMatch)}</Text>
+                    </View>
+                  )}
+                </View>
+
+                <View style={styles.infoStack}>
+                  <InfoRow label="Bio" value={topMatch.bio?.trim() || 'Bio not shown yet.'} />
+                  <InfoRow label="Budget" value={formatBudget(topMatch.budgetMin, topMatch.budgetMax)} />
+                  <InfoRow label="Move-in date" value={formatDate(topMatch.moveInDate)} />
+                  <InfoRow
+                    label="Compatibility"
+                    value={topMatch.passedFilters ? topDomainSummary(topMatch.domains) : topMatch.failures[0] ?? 'Dealbreaker mismatch'}
+                  />
+                </View>
+
+                <View style={styles.actionRow}>
+                  <TouchableOpacity style={[styles.roundAction, styles.rejectAction]} disabled>
+                    <Ionicons name="close" size={24} color="#B42318" />
+                  </TouchableOpacity>
+                  <TouchableOpacity style={[styles.roundAction, styles.acceptAction]} disabled>
+                    <Ionicons name="checkmark" size={24} color="#067647" />
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ) : (
+              <View style={styles.stateCard}>
+                <Text style={styles.emptyTitle}>No matches yet</Text>
+                <Text style={styles.emptyText}>
+                  No completed roommate profiles are visible yet.
                 </Text>
               </View>
-            ))}
-          </View>
+            )}
+
+            <View style={styles.feedMetaRow}>
+              <Text style={styles.feedMetaText}>
+                {matches.length > 0
+                  ? `${matches.length} ranked ${skippedCount > 0 ? `- ${skippedCount} incomplete skipped` : ''}`
+                  : 'Waiting for completed profiles'}
+              </Text>
+              <TouchableOpacity style={styles.refreshBtn} onPress={loadRankings} disabled={loadingMatches}>
+                <Ionicons name="refresh" size={16} color={PRIMARY} />
+                <Text style={styles.refreshText}>Refresh</Text>
+              </TouchableOpacity>
+            </View>
+          </>
+        ) : (
+          <>
+            <View style={styles.profileTopBar}>
+              <Text style={styles.logo}>HM</Text>
+              <TouchableOpacity style={styles.iconBtn} disabled>
+                <Ionicons name="settings-outline" size={22} color={TEXT} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.profileSummary}>
+              <TouchableOpacity
+                style={styles.avatarLarge}
+                onPress={handleChooseProfilePhoto}
+                disabled={!selfProfile || updatingPhoto}
+              >
+                {selfProfile?.avatar_url && !failedImageUrls.has(selfProfile.avatar_url) ? (
+                  <Image
+                    source={{ uri: selfProfile.avatar_url }}
+                    style={[styles.profileImage, styles.avatarImage]}
+                    onError={() => markImageFailed(selfProfile.avatar_url as string)}
+                  />
+                ) : (
+                  <Text style={styles.avatarInitial}>{selfProfile ? displayProfileInitial(selfProfile) : 'H'}</Text>
+                )}
+                <View style={styles.photoEditBadge}>
+                  {updatingPhoto ? (
+                    <ActivityIndicator color="#fff" size="small" />
+                  ) : (
+                    <Ionicons name="camera-outline" size={18} color="#fff" />
+                  )}
+                </View>
+              </TouchableOpacity>
+              <Text style={styles.profileName}>
+                {selfProfile ? displayProfileName(selfProfile) : 'HabiMatch User'}
+              </Text>
+              <Text style={styles.profileMeta}>
+                {selfProfile
+                  ? formatSelfProfileMeta(selfProfile)
+                  : 'Profile details unavailable'}
+              </Text>
+            </View>
+
+            <View style={styles.profileSection}>
+              <Text style={styles.profileLabel}>Display name</Text>
+              <TextInput
+                style={styles.profileInput}
+                value={profileName}
+                onChangeText={setProfileName}
+                editable={Boolean(selfProfile) && !savingProfile}
+                placeholder="Your name"
+                placeholderTextColor="#9CA3AF"
+                autoCapitalize="words"
+              />
+            </View>
+
+            <View style={styles.profileSection}>
+              <Text style={styles.profileLabel}>Bio</Text>
+              <TextInput
+                style={[styles.profileInput, styles.bioInput]}
+                value={profileBio}
+                onChangeText={setProfileBio}
+                editable={Boolean(selfProfile) && !savingProfile}
+                placeholder="Write a short roommate bio"
+                placeholderTextColor="#9CA3AF"
+                multiline
+                textAlignVertical="top"
+              />
+            </View>
+
+            <View style={styles.profileSection}>
+              <Text style={styles.profileLabel}>Location</Text>
+              <TextInput
+                style={styles.profileInput}
+                value={profileLocation}
+                onChangeText={setProfileLocation}
+                editable={Boolean(selfProfile) && !savingProfile}
+                placeholder="City, state"
+                placeholderTextColor="#9CA3AF"
+                autoCapitalize="words"
+              />
+            </View>
+
+            {profileSaveError ? <Text style={styles.authError}>{profileSaveError}</Text> : null}
+            {profileSaveMessage ? <Text style={styles.successText}>{profileSaveMessage}</Text> : null}
+
+            <TouchableOpacity
+              style={[
+                styles.profileAction,
+                (!selfProfile || savingProfile || !profileName.trim() || !profileLocation.trim()) && styles.btnDisabled,
+              ]}
+              onPress={handleSaveProfile}
+              disabled={!selfProfile || savingProfile || !profileName.trim() || !profileLocation.trim()}
+            >
+              {savingProfile
+                ? <ActivityIndicator color={PRIMARY} />
+                : <Text style={styles.profileActionText}>Save profile</Text>}
+            </TouchableOpacity>
+
+            {authError ? <Text style={styles.authError}>{authError}</Text> : null}
+
+            <TouchableOpacity
+              style={[styles.profileAction, signingOut && styles.btnDisabled]}
+              onPress={handleSignOut}
+              disabled={signingOut}
+            >
+              {signingOut
+                ? <ActivityIndicator color={PRIMARY} />
+                : <Text style={styles.profileActionText}>Sign out</Text>}
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.deleteAction} disabled>
+              <Text style={styles.deleteActionText}>Delete account</Text>
+            </TouchableOpacity>
+          </>
         )}
+      </ScrollView>
+
+      <View style={styles.tabBar}>
+        <TouchableOpacity style={styles.tabItem} disabled>
+          <Ionicons name="chatbubble-outline" size={20} color={MUTED} />
+          <Text style={styles.tabText}>Messages</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.tabItem} onPress={() => setActiveTab('feed')}>
+          <Ionicons name="albums-outline" size={20} color={activeTab === 'feed' ? PRIMARY : MUTED} />
+          <Text style={[styles.tabText, activeTab === 'feed' && styles.tabTextActive]}>Feed</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.tabItem} onPress={() => setActiveTab('profile')}>
+          <Ionicons name="person-outline" size={20} color={activeTab === 'profile' ? PRIMARY : MUTED} />
+          <Text style={[styles.tabText, activeTab === 'profile' && styles.tabTextActive]}>Profile</Text>
+        </TouchableOpacity>
       </View>
+    </View>
+  );
+}
 
-      {authError ? <Text style={styles.authError}>{authError}</Text> : null}
-
-      <TouchableOpacity
-        style={[styles.signOutBtn, signingOut && styles.btnDisabled]}
-        onPress={handleSignOut}
-        disabled={signingOut}
-      >
-        {signingOut
-          ? <ActivityIndicator color="#fff" />
-          : <Text style={styles.signOutText}>Sign out</Text>}
-      </TouchableOpacity>
-    </ScrollView>
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View>
+      <Text style={styles.infoLabel}>{label}</Text>
+      <Text style={styles.infoValue}>{value}</Text>
+    </View>
   );
 }
 
@@ -315,10 +627,10 @@ function toParticipant(
 }
 
 function toMatchPreferences(row: PreferenceRecord): MatchPreferences | null {
-  const preferredAgeMin = requiredNumber(row.preferred_age_min);
-  const preferredAgeMax = requiredNumber(row.preferred_age_max);
   const budgetMin = requiredNumber(row.budget_min);
   const budgetMax = requiredNumber(row.budget_max);
+  const partnerStaysOver = requiredScore(row.partner_stays_over);
+  const okWithPartnersStaying = requiredScore(row.ok_with_partners_staying);
   const sleepBehaviorScore = requiredScore(row.sleep_behavior_score);
   const sleepToleranceScore = requiredScore(row.sleep_tolerance_score);
   const cleanBehaviorScore = requiredScore(row.clean_behavior_score);
@@ -334,12 +646,11 @@ function toMatchPreferences(row: PreferenceRecord): MatchPreferences | null {
   const cohabitationToleranceScore = requiredScore(row.cohabitation_tolerance_score);
 
   if (
-    preferredAgeMin === null
-    || preferredAgeMax === null
-    || budgetMin === null
+    budgetMin === null
     || budgetMax === null
+    || partnerStaysOver === null
+    || okWithPartnersStaying === null
     || !isIsoDate(row.move_in_date)
-    || preferredAgeMax < preferredAgeMin
     || budgetMax < budgetMin
     || sleepBehaviorScore === null
     || sleepToleranceScore === null
@@ -367,13 +678,9 @@ function toMatchPreferences(row: PreferenceRecord): MatchPreferences | null {
     okWithAlcohol: optionalBoolean(row.ok_with_alcohol, true),
     hasPets: optionalBoolean(row.has_pets, false),
     okWithPets: optionalBoolean(row.ok_with_pets, true),
-    partnerStaysOver: optionalBoolean(row.partner_stays_over, false),
-    okWithPartnersStaying: optionalBoolean(row.ok_with_partners_staying, true),
-    sharesFood: optionalBoolean(row.shares_food, false),
-    okWithCoed: optionalBoolean(row.ok_with_coed, true),
+    partnerStaysOver,
+    okWithPartnersStaying,
     studyOrWfh: optionalBoolean(row.study_or_wfh, false),
-    preferredAgeMin,
-    preferredAgeMax,
     budgetMin,
     budgetMax,
     moveInDate: row.move_in_date,
@@ -390,6 +697,32 @@ function toMatchPreferences(row: PreferenceRecord): MatchPreferences | null {
     conflictBehaviorScore,
     conflictToleranceScore,
     cohabitationToleranceScore,
+  };
+}
+
+function toRankedProfile(
+  participant: MatchParticipant,
+  profile: ProfileRecord,
+  preferences: PreferenceRecord,
+  ranking: {
+    score: number;
+    passedFilters: boolean;
+    failures: string[];
+    domains: Record<DomainKey, number>;
+  },
+): RankedMatch {
+  return {
+    userId: participant.userId,
+    fullName: profile.full_name,
+    avatarUrl: profile.avatar_url,
+    bio: profile.bio,
+    location: profile.location,
+    age: participant.age,
+    gender: participant.gender,
+    budgetMin: preferences.budget_min ?? 0,
+    budgetMax: preferences.budget_max ?? 0,
+    moveInDate: preferences.move_in_date ?? '',
+    ...ranking,
   };
 }
 
@@ -448,6 +781,54 @@ function formatPercent(value: number): number {
   return Math.round(value * 100);
 }
 
+function displayName(match: RankedMatch): string {
+  return match.fullName?.trim() || `User ${shortUserId(match.userId)}`;
+}
+
+function displayInitial(match: RankedMatch): string {
+  return displayName(match).charAt(0).toUpperCase();
+}
+
+function displayProfileName(profile: ProfileRecord): string {
+  return profile.full_name?.trim() || `User ${shortUserId(profile.id)}`;
+}
+
+function displayProfileInitial(profile: ProfileRecord): string {
+  return displayProfileName(profile).charAt(0).toUpperCase();
+}
+
+function formatBudget(min: number, max: number): string {
+  if (!min || !max) return 'Budget not shown';
+  return `$${min.toLocaleString()} - $${max.toLocaleString()}`;
+}
+
+function formatDate(value: string): string {
+  if (!isIsoDate(value)) return 'Date not shown';
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatProfileMeta(match: RankedMatch): string {
+  return [
+    formatGender(match.gender),
+    `${match.age}`,
+    match.location?.trim() || null,
+  ].filter(Boolean).join(' - ');
+}
+
+function formatSelfProfileMeta(profile: ProfileRecord): string {
+  const age = calculateAge(profile.birthdate);
+  return [
+    formatGender(normalizeGender(profile.gender)),
+    age ? `${age}` : null,
+    profile.location?.trim() || null,
+  ].filter(Boolean).join(' - ');
+}
+
 function topDomainSummary(domains: Record<DomainKey, number>): string {
   return Object.entries(domains)
     .sort(([, left], [, right]) => right - left)
@@ -457,109 +838,142 @@ function topDomainSummary(domains: Record<DomainKey, number>): string {
 }
 
 const styles = StyleSheet.create({
+  shell: {
+    flex: 1,
+    backgroundColor: '#F5F7FB',
+  },
   root: {
     flexGrow: 1,
-    padding: 24,
-    backgroundColor: '#f5f7fb',
+    paddingHorizontal: 20,
+    paddingTop: 58,
+    paddingBottom: 116,
   },
-  header: {
-    marginTop: 28,
+  topBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
     marginBottom: 18,
   },
-  title: {
+  logo: {
+    color: TEXT,
+    fontSize: 18,
+    fontWeight: '800',
+    letterSpacing: 0,
+  },
+  screenTitle: {
+    color: TEXT,
     fontSize: 26,
+    fontWeight: '800',
+    marginTop: 8,
+  },
+  iconTextBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    borderWidth: 1,
+    borderColor: '#D8E6F5',
+    backgroundColor: CARD,
+    borderRadius: 999,
+    paddingHorizontal: 13,
+    paddingVertical: 9,
+  },
+  iconText: {
+    color: PRIMARY,
+    fontSize: 13,
     fontWeight: '700',
-    color: '#111827',
-    marginBottom: 6,
   },
-  subtitle: {
-    fontSize: 15,
-    color: '#5E6A7D',
-    lineHeight: 21,
-  },
-  panel: {
-    backgroundColor: '#fff',
-    borderRadius: 18,
+  heroCard: {
+    backgroundColor: CARD,
+    borderRadius: 20,
     padding: 18,
     borderWidth: 1,
     borderColor: '#E4EAF2',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 4,
   },
-  panelHeader: {
+  matchHeader: {
     flexDirection: 'row',
-    alignItems: 'flex-start',
     justifyContent: 'space-between',
+    alignItems: 'flex-start',
     gap: 12,
     marginBottom: 14,
   },
-  sectionLabel: {
-    fontSize: 17,
-    fontWeight: '700',
-    color: '#111827',
-  },
-  panelSubtitle: {
-    marginTop: 3,
-    fontSize: 13,
-    color: '#6B7280',
-  },
-  refreshBtn: {
-    borderWidth: 1,
-    borderColor: '#CFE0F3',
-    borderRadius: 999,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-  },
-  refreshText: {
-    color: PRIMARY,
-    fontWeight: '700',
-    fontSize: 13,
-  },
-  errorBanner: {
-    color: '#B42318',
-    backgroundColor: '#FEEDEB',
-    borderRadius: 10,
-    padding: 10,
-    marginBottom: 12,
-    fontSize: 13,
-  },
-  loadingWrap: {
-    alignItems: 'center',
-    paddingVertical: 30,
-  },
-  loadingText: {
-    marginTop: 10,
-    color: '#6B7280',
-    fontSize: 14,
-  },
-  matchList: {
-    gap: 10,
-  },
-  emptyText: {
-    color: '#6B7280',
-    fontSize: 14,
-    lineHeight: 20,
-  },
-  matchCard: {
-    borderWidth: 1,
-    borderColor: '#E7EDF5',
-    borderRadius: 14,
-    padding: 14,
-    backgroundColor: '#FCFDFF',
-  },
-  matchTopRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    gap: 12,
-  },
   matchName: {
-    color: '#111827',
-    fontSize: 15,
-    fontWeight: '700',
+    color: TEXT,
+    fontSize: 20,
+    fontWeight: '800',
   },
   matchMeta: {
-    color: '#6B7280',
+    color: MUTED,
+    fontSize: 14,
+    marginTop: 4,
+  },
+  photoFrame: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: 16,
+    backgroundColor: '#EEF3FA',
+    borderWidth: 1,
+    borderColor: '#E1E7F0',
+    overflow: 'hidden',
+    marginBottom: 16,
+  },
+  profileImage: {
+    width: '100%',
+    height: '100%',
+  },
+  avatarImage: {
+    borderRadius: 66,
+  },
+  photoFallback: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  photoInitial: {
+    color: PRIMARY,
+    fontSize: 72,
+    fontWeight: '800',
+  },
+  infoStack: {
+    gap: 12,
+    paddingBottom: 10,
+  },
+  infoLabel: {
+    color: TEXT,
     fontSize: 13,
-    marginTop: 3,
+    fontWeight: '800',
+    marginBottom: 3,
+  },
+  infoValue: {
+    color: '#4B5563',
+    fontSize: 15,
+    lineHeight: 21,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+    marginTop: 8,
+  },
+  roundAction: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  rejectAction: {
+    backgroundColor: '#FEEDEB',
+    borderColor: '#FAD4D0',
+  },
+  acceptAction: {
+    backgroundColor: '#ECFDF3',
+    borderColor: '#B7E4C7',
   },
   scorePill: {
     backgroundColor: '#EAF4FF',
@@ -578,31 +992,216 @@ const styles = StyleSheet.create({
   filteredText: {
     color: '#B54708',
   },
-  matchDetail: {
-    color: '#4B5563',
+  feedMetaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 16,
+  },
+  feedMetaText: {
+    flex: 1,
+    color: MUTED,
     fontSize: 13,
-    lineHeight: 18,
+  },
+  refreshBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    borderWidth: 1,
+    borderColor: '#CFE0F3',
+    backgroundColor: CARD,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  refreshText: {
+    color: PRIMARY,
+    fontWeight: '700',
+    fontSize: 13,
+  },
+  errorBanner: {
+    color: '#B42318',
+    backgroundColor: '#FEEDEB',
+    borderRadius: 10,
+    padding: 10,
+    marginBottom: 14,
+    fontSize: 13,
+  },
+  stateCard: {
+    backgroundColor: CARD,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#E4EAF2',
+    alignItems: 'center',
+    paddingVertical: 38,
+    paddingHorizontal: 20,
+  },
+  loadingText: {
     marginTop: 10,
+    color: MUTED,
+    fontSize: 14,
+  },
+  emptyTitle: {
+    color: TEXT,
+    fontSize: 18,
+    fontWeight: '800',
+    marginBottom: 8,
+  },
+  emptyText: {
+    color: MUTED,
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+  profileTopBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 22,
+  },
+  iconBtn: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: CARD,
+    borderWidth: 1,
+    borderColor: '#E4EAF2',
+  },
+  profileSummary: {
+    alignItems: 'center',
+    marginBottom: 28,
+  },
+  avatarLarge: {
+    width: 132,
+    height: 132,
+    borderRadius: 66,
+    backgroundColor: '#EAF4FF',
+    borderWidth: 1,
+    borderColor: '#D8E6F5',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 18,
+  },
+  photoEditBadge: {
+    position: 'absolute',
+    right: 4,
+    bottom: 4,
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: PRIMARY,
+    borderWidth: 2,
+    borderColor: CARD,
+  },
+  avatarInitial: {
+    color: PRIMARY,
+    fontSize: 44,
+    fontWeight: '800',
+  },
+  profileName: {
+    color: TEXT,
+    fontSize: 24,
+    fontWeight: '800',
+  },
+  profileMeta: {
+    color: MUTED,
+    fontSize: 14,
+    marginTop: 5,
+  },
+  profileSection: {
+    marginBottom: 22,
+  },
+  profileLabel: {
+    color: TEXT,
+    fontSize: 17,
+    fontWeight: '800',
+    marginBottom: 8,
+  },
+  profileInput: {
+    borderWidth: 1,
+    borderColor: '#D8E6F5',
+    borderRadius: 12,
+    backgroundColor: CARD,
+    color: TEXT,
+    fontSize: 15,
+    lineHeight: 22,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  bioInput: {
+    minHeight: 112,
+  },
+  successText: {
+    color: '#067647',
+    textAlign: 'center',
+    marginBottom: 12,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  profileBody: {
+    color: '#4B5563',
+    fontSize: 15,
+    lineHeight: 22,
   },
   authError: {
     color: '#B42318',
     textAlign: 'center',
-    marginTop: 16,
+    marginBottom: 12,
   },
-  signOutBtn: {
-    backgroundColor: PRIMARY,
+  profileAction: {
+    borderWidth: 1,
+    borderColor: '#D8E6F5',
+    backgroundColor: CARD,
     paddingVertical: 14,
     borderRadius: 12,
     alignItems: 'center',
-    marginTop: 18,
-    marginBottom: 20,
+    marginBottom: 14,
   },
   btnDisabled: {
     opacity: 0.7,
   },
-  signOutText: {
-    color: '#fff',
+  profileActionText: {
+    color: PRIMARY,
     fontSize: 16,
     fontWeight: '700',
+  },
+  deleteAction: {
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  deleteActionText: {
+    color: '#B42318',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  tabBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: 'row',
+    backgroundColor: CARD,
+    borderTopWidth: 1,
+    borderTopColor: '#E4EAF2',
+    paddingTop: 10,
+    paddingBottom: 28,
+  },
+  tabItem: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 4,
+  },
+  tabText: {
+    color: MUTED,
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  tabTextActive: {
+    color: PRIMARY,
   },
 });

--- a/mobile/src/screens/ProfilePhotoScreen.tsx
+++ b/mobile/src/screens/ProfilePhotoScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import { supabase } from '../lib/supabase';
+import { uploadProfilePhoto } from '../lib/profilePhotos';
 
 type Props = {
   userId: string;
@@ -51,10 +52,11 @@ export default function ProfilePhotoScreen({ userId, onComplete }: Props) {
     }
 
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: 'images',
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
+      base64: true,
     });
 
     if (!result.canceled) {
@@ -85,31 +87,8 @@ export default function ProfilePhotoScreen({ userId, onComplete }: Props) {
     setSaving(true);
 
     try {
-      const response = await fetch(selectedAsset.uri);
-      const imageBlob = await response.blob();
-      const fileExtension =
-        selectedAsset.fileName?.split('.').pop()?.toLowerCase()
-        ?? selectedAsset.mimeType?.split('/').pop()?.toLowerCase()
-        ?? 'jpg';
-      const contentType = selectedAsset.mimeType ?? imageBlob.type ?? 'image/jpeg';
-      const filePath = `${userId}/${Date.now()}.${fileExtension}`;
-
-      const { error: uploadError } = await supabase.storage
-        .from('profile-photos')
-        .upload(filePath, imageBlob, {
-          contentType,
-          upsert: true,
-        });
-
-      if (uploadError) {
-        throw uploadError;
-      }
-
-      const { data: publicUrlData } = supabase.storage
-        .from('profile-photos')
-        .getPublicUrl(filePath);
-
-      await saveProfileAvatar(publicUrlData.publicUrl);
+      const avatarUrl = await uploadProfilePhoto(userId, selectedAsset);
+      await saveProfileAvatar(avatarUrl);
       onComplete();
     } catch (uploadFailure) {
       const detail =

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,408 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "HabiMatch"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260505211921_add_discovery_decisions.sql
+++ b/supabase/migrations/20260505211921_add_discovery_decisions.sql
@@ -1,0 +1,32 @@
+create table if not exists public.discovery_decisions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  target_user_id uuid not null references auth.users (id) on delete cascade,
+  decision text not null check (decision in ('pass', 'like')),
+  created_at timestamptz not null default now(),
+  unique (user_id, target_user_id)
+);
+
+alter table public.discovery_decisions enable row level security;
+
+drop policy if exists "Users can insert own discovery decisions" on public.discovery_decisions;
+drop policy if exists "Users can read own discovery decisions" on public.discovery_decisions;
+drop policy if exists "Users can update own discovery decisions" on public.discovery_decisions;
+
+create policy "Users can insert own discovery decisions"
+  on public.discovery_decisions for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can read own discovery decisions"
+  on public.discovery_decisions for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can update own discovery decisions"
+  on public.discovery_decisions for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+grant select, insert, update on table public.discovery_decisions to authenticated;;

--- a/supabase/migrations/20260510053317_discovery_decisions_policies.sql
+++ b/supabase/migrations/20260510053317_discovery_decisions_policies.sql
@@ -1,0 +1,57 @@
+alter table public.discovery_decisions enable row level security;
+
+alter table public.discovery_decisions
+drop constraint if exists discovery_decisions_decision_check;
+
+alter table public.discovery_decisions
+add constraint discovery_decisions_decision_check
+check (decision in ('like', 'dislike'));
+
+delete from public.discovery_decisions current_decision
+using public.discovery_decisions newer_decision
+where current_decision.user_id = newer_decision.user_id
+  and current_decision.target_user_id = newer_decision.target_user_id
+  and (
+    current_decision.created_at < newer_decision.created_at
+    or (
+      current_decision.created_at = newer_decision.created_at
+      and current_decision.id::text < newer_decision.id::text
+    )
+  );
+
+alter table public.discovery_decisions
+drop constraint if exists discovery_decisions_user_target_unique;
+
+alter table public.discovery_decisions
+add constraint discovery_decisions_user_target_unique
+unique (user_id, target_user_id);
+
+drop policy if exists "Users can read own discovery decisions" on public.discovery_decisions;
+drop policy if exists "Users can insert own discovery decisions" on public.discovery_decisions;
+drop policy if exists "Users can update own discovery decisions" on public.discovery_decisions;
+drop policy if exists "Users can delete own discovery decisions" on public.discovery_decisions;
+
+create policy "Users can read own discovery decisions"
+on public.discovery_decisions
+for select
+to authenticated
+using (user_id = auth.uid());
+
+create policy "Users can insert own discovery decisions"
+on public.discovery_decisions
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+create policy "Users can update own discovery decisions"
+on public.discovery_decisions
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "Users can delete own discovery decisions"
+on public.discovery_decisions
+for delete
+to authenticated
+using (user_id = auth.uid());


### PR DESCRIPTION
## Summary

This branch builds out the signed-in roommate dashboard/feed flow and wires it to the current Supabase tables.

## What changed

- Reworked the post-login home screen into a roommate feed/dashboard with profile details, compatibility score display, self-profile editing, and profile photo rendering.
- Added frontend compatibility scoring that compares completed profiles and lifestyle preference rows.
- Added like/dislike discovery decisions from the feed, including saving decisions to Supabase and filtering already-decided users out of future feed results.
- Added profile photo upload handling through the `profile-photos` bucket and improved image fallback behavior.
- Updated onboarding/profile flow so full name, location, birthday, gender, bio, and avatar data are tied back to the user profile row.
- Added Supabase SQL/migrations for completed-profile read access, profile photo storage policies, discovery decisions, and CLI migration tracking.
- Kept placeholder buttons like sort/settings/message non-functional where intended.

## Fixes included

- Fixed feed records showing generic or hard-coded user labels by using actual `profiles` table data.
- Fixed profile photo saving/display issues by uploading real image bytes and storing the public avatar URL.
- Fixed discovery decision values so both `like` and `dislike` are accepted by the database.
- Tightened Supabase storage policy handling so profile photo reads are not broader than necessary.

## Validation

- `cd mobile && npx tsc --noEmit` passed.
- `pytest` was attempted, but the local Python environment is missing `sqlalchemy`, so backend tests did not start.
- `supabase db push` successfully applied the latest discovery decision policy migration to the remote project.
