### PR TITLE
Fix profile photo uploads and account deletion

### DIFF
--- a/backend/sql/delete_my_account.sql
+++ b/backend/sql/delete_my_account.sql
@@ -1,0 +1,95 @@
+-- Paste into Supabase SQL Editor, then deploy the edge function (see below).
+
+create or replace function public.delete_my_user_data()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_direct_conversation_ids uuid[];
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  if to_regclass('public.discovery_decisions') is not null then
+    delete from public.discovery_decisions
+    where user_id = v_user_id
+       or target_user_id = v_user_id;
+  end if;
+
+  if to_regclass('public.participants') is not null
+     and to_regclass('public.conversations') is not null then
+    select array_agg(distinct p.conversation_id)
+    into v_direct_conversation_ids
+    from public.participants p
+    join public.conversations c on c.id = p.conversation_id
+    where p.user_id = v_user_id
+      and c.is_group = false;
+
+    if to_regclass('public.messages') is not null then
+      delete from public.messages
+      where sender_id = v_user_id;
+    end if;
+
+    delete from public.participants
+    where user_id = v_user_id;
+
+    if v_direct_conversation_ids is not null then
+      if to_regclass('public.messages') is not null then
+        delete from public.messages
+        where conversation_id = any (v_direct_conversation_ids);
+      end if;
+
+      delete from public.participants
+      where conversation_id = any (v_direct_conversation_ids);
+
+      delete from public.conversations
+      where id = any (v_direct_conversation_ids);
+    end if;
+  end if;
+
+  if to_regclass('public.lifestyle_preferences') is not null then
+    delete from public.lifestyle_preferences
+    where user_id = v_user_id;
+  end if;
+
+  if to_regclass('public.profiles') is not null then
+    delete from public.profiles
+    where id = v_user_id;
+  end if;
+end;
+$$;
+
+create or replace function public.delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  perform public.delete_my_user_data();
+
+  delete from auth.users
+  where id = v_user_id;
+
+  if exists (select 1 from auth.users where id = v_user_id) then
+    raise exception 'auth_user_delete_failed';
+  end if;
+end;
+$$;
+
+alter function public.delete_my_user_data() owner to postgres;
+alter function public.delete_my_account() owner to postgres;
+
+revoke all on function public.delete_my_user_data() from public;
+revoke all on function public.delete_my_account() from public;
+
+grant execute on function public.delete_my_user_data() to authenticated;
+grant execute on function public.delete_my_account() to authenticated;
+grant execute on function public.delete_my_user_data() to service_role;
+grant execute on function public.delete_my_account() to service_role;

--- a/mobile/src/lib/deleteAccount.ts
+++ b/mobile/src/lib/deleteAccount.ts
@@ -1,0 +1,86 @@
+import { supabase } from './supabase';
+import { getErrorMessage, getFunctionInvokeErrorMessage } from './errors';
+import { deleteProfilePhotos } from './profilePhotos';
+
+async function signOutLocally(): Promise<void> {
+  const { error: signOutError } = await supabase.auth.signOut({ scope: 'local' });
+  if (signOutError) {
+    throw signOutError;
+  }
+}
+
+async function deleteAccountViaEdgeFunction(): Promise<void> {
+  const { data, error } = await supabase.functions.invoke('delete-account', {
+    method: 'POST',
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  const payload = data as { error?: string; success?: boolean } | null;
+  if (payload?.error) {
+    throw new Error(payload.error);
+  }
+  if (!payload?.success) {
+    throw new Error('Account deletion did not complete.');
+  }
+}
+
+async function deleteAccountViaRpc(): Promise<void> {
+  const { error } = await supabase.rpc('delete_my_account');
+  if (error) {
+    throw error;
+  }
+}
+
+function shouldRetryWithEdgeFunction(rpcMessage: string): boolean {
+  const normalized = rpcMessage.toLowerCase();
+  return (
+    normalized.includes('auth_user_delete_failed') ||
+    normalized.includes('could not find the function') ||
+    normalized.includes('does not exist')
+  );
+}
+
+async function deleteStoredProfilePhotos(): Promise<void> {
+  const { data: authData, error: userError } = await supabase.auth.getUser();
+  if (userError) {
+    throw userError;
+  }
+
+  const userId = authData.user?.id;
+  if (!userId) {
+    throw new Error('No signed-in user found.');
+  }
+
+  await deleteProfilePhotos(userId);
+}
+
+export async function deleteAccount(): Promise<void> {
+  await deleteStoredProfilePhotos();
+
+  const { error: rpcError } = await supabase.rpc('delete_my_account');
+
+  if (!rpcError) {
+    await signOutLocally();
+    return;
+  }
+
+  const rpcMessage = getErrorMessage(rpcError, 'Could not delete your account.');
+
+  if (!shouldRetryWithEdgeFunction(rpcMessage)) {
+    throw new Error(rpcMessage);
+  }
+
+  try {
+    await deleteAccountViaEdgeFunction();
+    await signOutLocally();
+  } catch (edgeFailure) {
+    const edgeMessage = await getFunctionInvokeErrorMessage(
+      edgeFailure,
+      'Could not delete your account.',
+    );
+    throw new Error(edgeMessage || rpcMessage);
+  }
+}

--- a/mobile/src/lib/errors.ts
+++ b/mobile/src/lib/errors.ts
@@ -1,0 +1,54 @@
+import { FunctionsHttpError } from '@supabase/supabase-js';
+
+type ErrorLike = {
+  message?: string;
+  details?: string;
+  hint?: string;
+};
+
+export function getErrorMessage(error: unknown, fallback = 'Something went wrong.'): string {
+  if (!error) return fallback;
+  if (typeof error === 'string') return error;
+  if (error instanceof Error && error.message && error.message !== 'Edge Function returned a non-2xx status code') {
+    return error.message;
+  }
+
+  const record = error as ErrorLike;
+  const parts = [record.message, record.details, record.hint].filter(
+    (part): part is string => Boolean(part?.trim()),
+  );
+
+  if (parts.length > 0) {
+    const combined = parts.join(' ');
+    if (combined !== 'Edge Function returned a non-2xx status code') {
+      return combined;
+    }
+  }
+
+  return fallback;
+}
+
+export async function getFunctionInvokeErrorMessage(
+  error: unknown,
+  fallback = 'Account deletion failed.',
+): Promise<string> {
+  if (error instanceof FunctionsHttpError) {
+    const response = error.context as Response | undefined;
+    if (response) {
+      try {
+        const body = (await response.clone().json()) as { error?: string; message?: string };
+        if (body.error?.trim()) return body.error;
+        if (body.message?.trim()) return body.message;
+      } catch {
+        try {
+          const text = await response.clone().text();
+          if (text.trim()) return text;
+        } catch {
+          // ignore parse failures
+        }
+      }
+    }
+  }
+
+  return getErrorMessage(error, fallback);
+}

--- a/mobile/src/lib/profilePhotos.ts
+++ b/mobile/src/lib/profilePhotos.ts
@@ -84,3 +84,30 @@ export async function uploadProfilePhoto(userId: string, asset: ImageAsset): Pro
 
   return publicUrlData.publicUrl;
 }
+
+export async function deleteProfilePhotos(userId: string): Promise<void> {
+  const { data: files, error: listError } = await supabase.storage
+    .from('profile-photos')
+    .list(userId);
+
+  if (listError) {
+    const message = listError.message.toLowerCase();
+    if (message.includes('not found') || message.includes('does not exist')) {
+      return;
+    }
+    throw listError;
+  }
+
+  const paths = (files ?? [])
+    .filter(file => file.name && file.id !== null)
+    .map(file => `${userId}/${file.name}`);
+
+  if (paths.length === 0) {
+    return;
+  }
+
+  const { error: removeError } = await supabase.storage.from('profile-photos').remove(paths);
+  if (removeError) {
+    throw removeError;
+  }
+}

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   Animated,
   Image,
   Modal,
@@ -16,6 +17,8 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import { supabase } from '../lib/supabase';
+import { deleteAccount } from '../lib/deleteAccount';
+import { getErrorMessage } from '../lib/errors';
 import { uploadProfilePhoto } from '../lib/profilePhotos';
 import { checkMutualMatch } from '../lib/messaging';
 import MessagesScreen, { type ChatTarget } from './MessagesScreen';
@@ -144,6 +147,8 @@ const PREFERENCE_COLUMNS = [
 
 export default function HomeScreen() {
   const [signingOut, setSigningOut] = useState(false);
+  const [deletingAccount, setDeletingAccount] = useState(false);
+  const [deleteAccountError, setDeleteAccountError] = useState('');
   const [loadingMatches, setLoadingMatches] = useState(true);
   const [refreshingFeed, setRefreshingFeed] = useState(false);
   const [authError, setAuthError] = useState('');
@@ -327,6 +332,35 @@ export default function HomeScreen() {
     } finally {
       setSigningOut(false);
     }
+  };
+
+  const confirmDeleteAccount = async () => {
+    setAuthError('');
+    setDeleteAccountError('');
+    setDeletingAccount(true);
+    try {
+      await deleteAccount();
+      setShowProfileSettings(false);
+    } catch (deleteFailure) {
+      const detail = getErrorMessage(deleteFailure, 'Could not delete your account.');
+      setDeleteAccountError(detail);
+      setAuthError(detail);
+      Alert.alert('Could not delete account', detail);
+    } finally {
+      setDeletingAccount(false);
+    }
+  };
+
+  const handleDeleteAccount = () => {
+    setDeleteAccountError('');
+    Alert.alert(
+      'Delete account?',
+      'This permanently removes your profile, photos, matches, and messages. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Delete account', style: 'destructive', onPress: () => void confirmDeleteAccount() },
+      ],
+    );
   };
 
   const handleSaveProfile = async () => {
@@ -956,12 +990,12 @@ export default function HomeScreen() {
             </View>
 
             <TouchableOpacity
-              style={[styles.settingsAction, signingOut && styles.btnDisabled]}
+              style={[styles.settingsAction, (signingOut || deletingAccount) && styles.btnDisabled]}
               onPress={() => {
                 setShowProfileSettings(false);
                 void handleSignOut();
               }}
-              disabled={signingOut}
+              disabled={signingOut || deletingAccount}
             >
               {signingOut ? (
                 <ActivityIndicator color={PRIMARY} />
@@ -973,12 +1007,29 @@ export default function HomeScreen() {
               )}
             </TouchableOpacity>
 
-            <TouchableOpacity style={[styles.settingsAction, styles.deleteSettingsAction]} disabled>
-              <Ionicons name="trash-outline" size={20} color="#B42318" />
-              <Text style={styles.deleteActionText}>Delete account</Text>
+            <TouchableOpacity
+              style={[
+                styles.settingsAction,
+                styles.deleteSettingsAction,
+                deletingAccount && styles.btnDisabled,
+              ]}
+              onPress={handleDeleteAccount}
+              disabled={deletingAccount}
+            >
+              {deletingAccount ? (
+                <ActivityIndicator color="#B42318" />
+              ) : (
+                <>
+                  <Ionicons name="trash-outline" size={20} color="#B42318" />
+                  <Text style={styles.deleteActionText}>Delete account</Text>
+                </>
+              )}
             </TouchableOpacity>
+            {deleteAccountError ? (
+              <Text style={styles.settingsError}>{deleteAccountError}</Text>
+            ) : null}
             <Text style={styles.settingsHint}>
-              Account deletion needs backend support before it can be enabled.
+              Deleting your account is permanent and cannot be undone.
             </Text>
           </View>
         </View>
@@ -1659,12 +1710,17 @@ const styles = StyleSheet.create({
   deleteSettingsAction: {
     borderColor: '#FAD4D0',
     backgroundColor: '#FFF7F6',
-    opacity: 0.65,
   },
   settingsHint: {
     color: MUTED,
     fontSize: 12,
     lineHeight: 17,
+  },
+  settingsError: {
+    color: '#B42318',
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: 8,
   },
   tabBar: {
     position: 'absolute',

--- a/mobile/tests/deleteAccountContract.test.ts
+++ b/mobile/tests/deleteAccountContract.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, test } from 'node:test';
+
+const root = resolve(process.cwd());
+
+const readSource = (path: string): string =>
+  readFileSync(resolve(root, path), 'utf8');
+
+describe('delete account contract', () => {
+  test('uses database RPC first and edge function only as auth fallback', () => {
+    const lib = readSource('src/lib/deleteAccount.ts');
+
+    const mainFlow = lib.split('export async function deleteAccount')[1] ?? '';
+    const rpcIndex = mainFlow.indexOf("rpc('delete_my_account')");
+    const edgeIndex = mainFlow.indexOf('deleteAccountViaEdgeFunction');
+    assert.ok(rpcIndex >= 0);
+    assert.ok(edgeIndex >= 0);
+    assert.ok(rpcIndex < edgeIndex);
+    assert.match(lib, /deleteProfilePhotos/);
+    assert.match(lib, /shouldRetryWithEdgeFunction/);
+    assert.match(lib, /getFunctionInvokeErrorMessage/);
+  });
+
+  test('wires profile settings delete action to Supabase cleanup', () => {
+    const home = readSource('src/screens/HomeScreen.tsx');
+
+    assert.match(home, /handleDeleteAccount/);
+    assert.match(home, /deleteAccountError/);
+    assert.match(home, /Alert\.alert\('Could not delete account'/);
+    assert.doesNotMatch(home, /needs backend support before it can be enabled/);
+  });
+});

--- a/mobile/tests/profileEditContract.test.ts
+++ b/mobile/tests/profileEditContract.test.ts
@@ -17,10 +17,11 @@ describe('profile edit contract', () => {
     assert.match(source, /Profile settings/);
     assert.match(source, /handleSignOut/);
     assert.match(source, /Delete account/);
+    assert.match(source, /handleDeleteAccount/);
 
-    const profileBody = source.split('Profile settings', 1)[0];
-    assert.doesNotMatch(profileBody, /Sign out/);
-    assert.doesNotMatch(profileBody, /Delete account/);
+    const profileBody = source.split('<Text style={styles.settingsTitle}>Profile settings</Text>', 1)[0];
+    assert.doesNotMatch(profileBody, /<Text style={styles\.settingsActionText}>Sign out<\/Text>/);
+    assert.doesNotMatch(profileBody, /<Text style={styles\.deleteActionText}>Delete account<\/Text>/);
   });
 
   test('lets the profile tab launch questionnaire preference updates', () => {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -366,6 +366,9 @@ authorization_url_path = "/oauth/consent"
 # Allow dynamic client registration
 allow_dynamic_registration = false
 
+[functions.delete-account]
+verify_jwt = true
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,100 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+    const serviceRoleKey =
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? Deno.env.get('SERVICE_ROLE_KEY') ?? '';
+
+    if (!supabaseUrl || !supabaseAnonKey || !serviceRoleKey) {
+      return new Response(
+        JSON.stringify({
+          error:
+            'Server configuration error. Redeploy delete-account or run delete_my_account.sql in SQL Editor.',
+        }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const supabaseUser = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabaseUser.auth.getUser();
+
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: userError?.message ?? 'Not authenticated' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { error: cleanupError } = await supabaseUser.rpc('delete_my_user_data');
+    if (cleanupError) {
+      return new Response(
+        JSON.stringify({
+          error: `${cleanupError.message}. Run backend/sql/delete_my_account.sql in Supabase SQL Editor.`,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { error: deleteAuthError } = await supabaseAdmin.auth.admin.deleteUser(user.id);
+    if (deleteAuthError) {
+      return new Response(JSON.stringify({ error: deleteAuthError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260602210000_profile_photo_storage_policies.sql
+++ b/supabase/migrations/20260602210000_profile_photo_storage_policies.sql
@@ -1,6 +1,4 @@
--- Fixes "New row violates row-level security policy" on profile photo upload.
--- Canonical copy: supabase/migrations/20260602210000_profile_photo_storage_policies.sql
-
+-- Profile photo bucket + storage RLS for mobile uploads (path: {user_id}/...).
 insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
 values (
   'profile-photos',

--- a/supabase/migrations/20260602220000_delete_my_account.sql
+++ b/supabase/migrations/20260602220000_delete_my_account.sql
@@ -1,0 +1,56 @@
+-- Removes the signed-in user's app data and auth record (security definer; no dashboard toggle).
+create or replace function public.delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, storage, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_direct_conversation_ids uuid[];
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  select array_agg(distinct p.conversation_id)
+  into v_direct_conversation_ids
+  from public.participants p
+  join public.conversations c on c.id = p.conversation_id
+  where p.user_id = v_user_id
+    and c.is_group = false;
+
+  delete from public.messages
+  where sender_id = v_user_id;
+
+  delete from public.participants
+  where user_id = v_user_id;
+
+  if v_direct_conversation_ids is not null then
+    delete from public.messages
+    where conversation_id = any (v_direct_conversation_ids);
+
+    delete from public.participants
+    where conversation_id = any (v_direct_conversation_ids);
+
+    delete from public.conversations
+    where id = any (v_direct_conversation_ids);
+  end if;
+
+  delete from public.lifestyle_preferences
+  where user_id = v_user_id;
+
+  delete from public.profiles
+  where id = v_user_id;
+
+  delete from storage.objects
+  where bucket_id = 'profile-photos'
+    and (storage.foldername(name))[1] = v_user_id::text;
+
+  delete from auth.users
+  where id = v_user_id;
+end;
+$$;
+
+revoke all on function public.delete_my_account() from public;
+grant execute on function public.delete_my_account() to authenticated;

--- a/supabase/migrations/20260602230000_fix_delete_my_account.sql
+++ b/supabase/migrations/20260602230000_fix_delete_my_account.sql
@@ -1,0 +1,94 @@
+-- Harden account deletion: optional messaging tables, postgres owner, split data vs auth.
+create or replace function public.delete_my_user_data()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_direct_conversation_ids uuid[];
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  if to_regclass('public.discovery_decisions') is not null then
+    delete from public.discovery_decisions
+    where user_id = v_user_id
+       or target_user_id = v_user_id;
+  end if;
+
+  if to_regclass('public.participants') is not null
+     and to_regclass('public.conversations') is not null then
+    select array_agg(distinct p.conversation_id)
+    into v_direct_conversation_ids
+    from public.participants p
+    join public.conversations c on c.id = p.conversation_id
+    where p.user_id = v_user_id
+      and c.is_group = false;
+
+    if to_regclass('public.messages') is not null then
+      delete from public.messages
+      where sender_id = v_user_id;
+    end if;
+
+    delete from public.participants
+    where user_id = v_user_id;
+
+    if v_direct_conversation_ids is not null then
+      if to_regclass('public.messages') is not null then
+        delete from public.messages
+        where conversation_id = any (v_direct_conversation_ids);
+      end if;
+
+      delete from public.participants
+      where conversation_id = any (v_direct_conversation_ids);
+
+      delete from public.conversations
+      where id = any (v_direct_conversation_ids);
+    end if;
+  end if;
+
+  if to_regclass('public.lifestyle_preferences') is not null then
+    delete from public.lifestyle_preferences
+    where user_id = v_user_id;
+  end if;
+
+  if to_regclass('public.profiles') is not null then
+    delete from public.profiles
+    where id = v_user_id;
+  end if;
+end;
+$$;
+
+create or replace function public.delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  perform public.delete_my_user_data();
+
+  delete from auth.users
+  where id = v_user_id;
+
+  if exists (select 1 from auth.users where id = v_user_id) then
+    raise exception 'auth_user_delete_failed';
+  end if;
+end;
+$$;
+
+alter function public.delete_my_user_data() owner to postgres;
+alter function public.delete_my_account() owner to postgres;
+
+revoke all on function public.delete_my_user_data() from public;
+revoke all on function public.delete_my_account() from public;
+
+grant execute on function public.delete_my_user_data() to authenticated;
+grant execute on function public.delete_my_account() to authenticated;
+grant execute on function public.delete_my_user_data() to service_role;
+grant execute on function public.delete_my_account() to service_role;

--- a/supabase/migrations/20260602240000_delete_account_no_storage_sql.sql
+++ b/supabase/migrations/20260602240000_delete_account_no_storage_sql.sql
@@ -1,0 +1,86 @@
+-- Supabase blocks direct DELETE on storage.objects; photos are removed via the Storage API in the app.
+create or replace function public.delete_my_user_data()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_direct_conversation_ids uuid[];
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  if to_regclass('public.discovery_decisions') is not null then
+    delete from public.discovery_decisions
+    where user_id = v_user_id
+       or target_user_id = v_user_id;
+  end if;
+
+  if to_regclass('public.participants') is not null
+     and to_regclass('public.conversations') is not null then
+    select array_agg(distinct p.conversation_id)
+    into v_direct_conversation_ids
+    from public.participants p
+    join public.conversations c on c.id = p.conversation_id
+    where p.user_id = v_user_id
+      and c.is_group = false;
+
+    if to_regclass('public.messages') is not null then
+      delete from public.messages
+      where sender_id = v_user_id;
+    end if;
+
+    delete from public.participants
+    where user_id = v_user_id;
+
+    if v_direct_conversation_ids is not null then
+      if to_regclass('public.messages') is not null then
+        delete from public.messages
+        where conversation_id = any (v_direct_conversation_ids);
+      end if;
+
+      delete from public.participants
+      where conversation_id = any (v_direct_conversation_ids);
+
+      delete from public.conversations
+      where id = any (v_direct_conversation_ids);
+    end if;
+  end if;
+
+  if to_regclass('public.lifestyle_preferences') is not null then
+    delete from public.lifestyle_preferences
+    where user_id = v_user_id;
+  end if;
+
+  if to_regclass('public.profiles') is not null then
+    delete from public.profiles
+    where id = v_user_id;
+  end if;
+end;
+$$;
+
+create or replace function public.delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  perform public.delete_my_user_data();
+
+  delete from auth.users
+  where id = v_user_id;
+
+  if exists (select 1 from auth.users where id = v_user_id) then
+    raise exception 'auth_user_delete_failed';
+  end if;
+end;
+$$;
+
+alter function public.delete_my_user_data() owner to postgres;
+alter function public.delete_my_account() owner to postgres;


### PR DESCRIPTION
## Summary

- Restores **profile photo uploads** after storage RLS was missing or incomplete by adding `profile-photos` bucket policies (public read, authenticated upload/update/delete in the user’s own folder).
- Enables **account deletion** from Profile settings: confirmation dialog, Storage API cleanup for uploaded photos, then `delete_my_account` RPC to remove app data and the auth user.
- Hardens deletion for real Supabase constraints: no direct `DELETE` on `storage.objects`, optional messaging tables, and an optional `delete-account` Edge Function fallback when SQL auth deletion fails.

## Problems solved

| Issue | Cause | Fix |
|--------|--------|-----|
| Profile picture upload failed with RLS error | `storage.objects` had no INSERT policy (or policies were removed when resetting the bucket) | Migration + SQL script recreate bucket policies |
| Delete account button did nothing | UI was intentionally `disabled` as a placeholder | Wired `handleDeleteAccount` with confirmation and deletion flow |
| Edge Function / RPC “non-2xx” errors | App called Edge Function first; generic error text hid the real failure | RPC-first flow; parse Edge Function response body for real messages |
| `Direct deletion from storage tables is not allowed` | `delete_my_account` tried `DELETE FROM storage.objects` | Remove storage SQL; delete photos via `storage.remove()` in the app before RPC |

## Supabase setup (required after merge)

Apply migrations (`supabase db push`) or run `backend/sql/delete_my_account.sql` and `backend/sql/tighten_profile_photo_storage_policies.sql` in the SQL Editor.

Optional: `supabase functions deploy delete-account` if `auth_user_delete_failed` appears on hosted projects.